### PR TITLE
ADDIC-13679 [Backend] Implementar los cambios necesarios a la librería ios-receipts-api para comptabilidad con PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,20 @@
 {
   "name": "additio/ios-receipts-api",
+  "description": "A library to get information on auto-renewing subscriptions from the App Store receipts API adapted for Additio purposes",
+  "homepage": "https://github.com/additio/ios-receipts-api",
   "license": "MIT",
-  "type": "project",
+  "type": "library",
+  "keywords": ["app store", "subscriptions", "ios", "receipts", "apple", "additio"],
+  "authors": [
+    {
+      "name": "Pere Garriga",
+      "email": "pere@additioapp.com"
+    }
+  ],
   "require": {
     "php": ">=7.4",
     "ext-json": "*",
-    "guzzlehttp/guzzle": "^7.0"
+    "guzzlehttp/guzzle": "^7.9.3"
   },
   "autoload": {
     "psr-4": {

--- a/lib/Model/AppStoreReceipt.php
+++ b/lib/Model/AppStoreReceipt.php
@@ -353,7 +353,7 @@ class AppStoreReceipt
     /**
      * @param array|null $pendingRenewalInfos
      */
-    public function setPendingRenewalInfos(array $pendingRenewalInfos = null): AppStoreReceipt
+    public function setPendingRenewalInfos(?array $pendingRenewalInfos = null): AppStoreReceipt
     {
         $this->pendingRenewalInfos = $pendingRenewalInfos;
 


### PR DESCRIPTION
- updating composer.json adding new information and using guzzle version the same than the additio-web will use.
- updating the code to be compatible with PHP 8.4